### PR TITLE
Delete a useless fd restore and correct the use of the v_buffer_size

### DIFF
--- a/vittf.h
+++ b/vittf.h
@@ -77,10 +77,6 @@ static int	v_read_return;
 
 #define V_REDIRECT_STDOUT_READ(v_buffer, v_buffer_size) \
 	do { \
-		if ((dup2(v_stdout_ref, 1)) == -1) {\
-			fprintf(stderr, "Dup2() error !\n"); \
-			exit(13); \
-		}\
 		v_read_return = read(v_pipe_redirect[0], v_buffer, v_buffer_size - 1); \
 		if (v_read_return == -1) {\
 			fprintf(stderr, "Read() error !\n"); \

--- a/vittf.h
+++ b/vittf.h
@@ -81,7 +81,7 @@ static int	v_read_return;
 			fprintf(stderr, "Dup2() error !\n"); \
 			exit(13); \
 		}\
-		v_read_return = read(v_pipe_redirect[0], v_buffer, v_buffer_size); \
+		v_read_return = read(v_pipe_redirect[0], v_buffer, v_buffer_size - 1); \
 		if (v_read_return == -1) {\
 			fprintf(stderr, "Read() error !\n"); \
 			exit(12); \


### PR DESCRIPTION
A useless restore of stdout in the V_REDIRECT_STDOUT_READ macro made impossible to use twice the READ macro between a SETUP/TEARDOWN for STDOUT.

Using the v_buffer_size as is could lead to a segfault adding the terminal NULL in the buffer. The user has to provide a buffer with enough space for the terminal NULL.
